### PR TITLE
Add development environment configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,17 @@
+# Base DevContainer Image
+FROM ghcr.io/containercraft/devcontainer:extra
+
+# List additional apt dependencies
+ARG DEBIAN_FRONTEND=noninteractive
+ARG APT_PKGS="\
+    git \
+    lz4 \
+    screenfetch"
+
+# Install dependencies
+RUN sudo apt-get update && \
+    sudo apt-get install -y $APT_PKGS && \
+    sudo apt-get clean && \
+    sudo rm -rf /var/lib/apt/lists/* && \
+    sudo rm -rf /tmp/* && \
+    sudo rm -rf /var/tmp/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,133 @@
+{
+    "name": "notes",
+    "remoteUser": "ubuntu",
+    "containerUser": "ubuntu",
+    "updateRemoteUserUID": true,
+    "initializeCommand": "echo 'Initializing Athena development environment...'",
+    "postCreateCommand": "sudo mkdir -p /home/ubuntu/.cache /home/ubuntu/.config /home/ubuntu/go/pkg /home/ubuntu/.azure /home/ubuntu/.cargo && sudo mkdir -p /home/ubuntu/.cache/starship && sudo chmod -R 777 /home/ubuntu/.cache && sudo chmod -R 755 /home/ubuntu/.config /home/ubuntu/go/pkg /home/ubuntu/.azure /home/ubuntu/.cargo && sudo chown -R ubuntu:ubuntu /home/ubuntu/.cache /home/ubuntu/.config /home/ubuntu/go/pkg /home/ubuntu/.azure /home/ubuntu/.cargo",
+    "shutdownAction": "stopContainer",
+    "overrideCommand": false,
+    "privileged": true,
+    "init": true,
+    "hostRequirements": {
+        "cpus": 4,
+        "memory": "4gb",
+        "storage": "16gb",
+        "gpu": false
+    },
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".",
+        "args": {
+            "DOCKER_BUILDKIT": "0"
+        }
+    },
+    "securityOpt": [
+        "seccomp=unconfined"
+    ],
+    "runArgs": [
+        "--privileged",
+        "--network=host"
+    ],
+    "forwardPorts": [
+        2222,
+        7681
+    ],
+    "portsAttributes": {
+        "2222": {
+            "label": "SSH Access",
+            "onAutoForward": "silent",
+            "requireLocalPort": false,
+            "elevateIfNeeded": true
+        },
+        "7681": {
+            "label": "TTYD Web Terminal",
+            "protocol": "http",
+            "onAutoForward": "openBrowser",
+            "requireLocalPort": false,
+            "elevateIfNeeded": false
+        }
+    },
+    "otherPortsAttributes": {
+        "onAutoForward": "silent",
+        "elevateIfNeeded": false,
+        "label": "Application Port",
+        "requireLocalPort": false
+    },
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/${localWorkspaceFolderBasename},type=bind,consistency=cached",
+    "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+    "mounts": [
+        "source=dind-var-lib-docker,target=/var/lib/docker,type=volume",
+        "source=athena-cache,target=/home/ubuntu/.cache,type=volume",
+        {
+            "source": "athena-config",
+            "target": "/home/ubuntu/.config",
+            "type": "volume"
+        },
+        {
+            "source": "athena-azure",
+            "target": "/home/ubuntu/.azure",
+            "type": "volume"
+        }
+    ],
+    "postStartCommand": "sudo mkdir -p ~/.cache/starship ~/.aws ~/.cache ~/.cargo ~/.azure ~/go/pkg && sudo chown -R ubuntu:ubuntu ~/.cache/starship ~/.cache ~/.cargo ~/.azure ~/go/pkg && sudo chmod -R 755 ~/.cache",
+    "postAttachCommand": "echo 'Welcome to the Athena development environment!' && echo 'Container ID: ${devcontainerId}' && ([ -f .envrc ] && direnv allow || true) && hostname && uptime",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-azuretools.vscode-docker",
+                "esbenp.prettier-vscode",
+                "bierner.markdown-mermaid",
+                "ms-vscode-remote.remote-containers"
+            ],
+            "settings": {
+                "terminal.integrated.defaultProfile.linux": "bash",
+                "terminal.integrated.profiles.linux": {
+                    "bash": {
+                        "path": "/bin/bash",
+                        "icon": "terminal-bash"
+                    }
+                },
+                "terminal.integrated.fontSize": 14,
+                "editor.fontSize": 14,
+                "editor.formatOnSave": true,
+                "editor.formatOnPaste": false,
+                "editor.rulers": [80, 120],
+                "editor.minimap.enabled": true,
+                "editor.bracketPairColorization.enabled": true,
+                "editor.guides.bracketPairs": true,
+                "editor.suggestSelection": "first",
+                "editor.tabSize": 2,
+                "editor.detectIndentation": true,
+                "files.trimTrailingWhitespace": true,
+                "files.insertFinalNewline": true,
+                "files.autoSave": "afterDelay",
+                "files.autoSaveDelay": 1000,
+                "explorer.confirmDragAndDrop": false,
+                "explorer.confirmDelete": true,
+                "workbench.startupEditor": "none",
+                "workbench.colorTheme": "Default Dark+",
+                "workbench.iconTheme": "vs-seti",
+                "telemetry.telemetryLevel": "off",
+                "git.autofetch": true,
+                "git.confirmSync": false,
+                "go.toolsManagement.autoUpdate": true,
+                "go.useLanguageServer": true,
+                "yaml.schemas": {
+                    "kubernetes": "*.yaml"
+                },
+                "docker.showStartPage": false
+            }
+        }
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+            "version": "latest",
+            "moby": true,
+            "dockerDashComposeVersion": "v2"
+        }
+    },
+    "containerEnv": {
+        "SHELL": "/bin/bash"
+    }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,40 @@
+{
+  "mcpServers": {
+    "memory": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "mcp/memory"]
+    },
+    "sequentialthinking": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "mcp/sequentialthinking"]
+    },
+    "git": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "mcp/git"]
+    },
+    "fetch": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "mcp/fetch"]
+    },
+    "openapi-schema": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "mcp/openapi-schema"]
+    },
+    "playwright": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "mcp/playwright"]
+    },
+    "github-official": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i", 
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "mcp/github-mcp-server"
+      ],
+      "env": {}
+    }
+  }
+}

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,128 @@
+{
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "perplexity-api-key",
+      "description": "Perplexity API Key",
+      "password": true
+    },
+    {
+      "type": "promptString",
+      "id": "github-token",
+      "description": "GitHub Personal Access Token",
+      "password": true
+    }
+  ],
+  "servers": {
+    "memory": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "mcp/memory"
+      ]
+    },
+    "sequentialthinking": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "mcp/sequentialthinking"
+      ]
+    },
+    "git": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "mcp/git"
+      ]
+    },
+    "fetch": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "mcp/fetch"
+      ]
+    },
+    "openapi-schema": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "mcp/openapi-schema"
+      ]
+    },
+    "playwright": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "mcp/playwright"
+      ]
+    },
+    "kubernetes": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "mcp/kubernetes"
+      ]
+    },
+    "pulumi": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "mcp/pulumi"
+      ]
+    },
+    "perplexity-ask": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "PERPLEXITY_API_KEY",
+        "mcp/perplexity-ask"
+      ],
+      "env": {
+        "PERPLEXITY_API_KEY": "${input:perplexity-api-key}"
+      }
+    },
+    "github-official": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "mcp/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github-token}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add devcontainer configuration for VSCode development
- Add MCP (Model Context Protocol) server configurations for both Claude Code and VSCode
- Includes comprehensive server setup: memory, git, fetch, playwright, openapi-schema, sequentialthinking, kubernetes, pulumi, perplexity-ask, and github-official

## Changes
- `.devcontainer/Dockerfile` - Base devcontainer image with ghcr.io/containercraft/devcontainer:extra
- `.devcontainer/devcontainer.json` - VSCode devcontainer configuration with GitHub Codespaces extensions and privileged container setup
- `.mcp.json` - Claude Code MCP server configuration for Docker-based MCP services
- `.vscode/mcp.json` - VSCode MCP server configuration with prompt inputs for API keys

## Test Plan
- [ ] Verify devcontainer builds successfully
- [ ] Test MCP server configurations in both Claude Code and VSCode
- [ ] Ensure all required extensions are installed
- [ ] Validate Docker-based MCP services start correctly